### PR TITLE
Dtype for kill

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -86,6 +86,9 @@ parser.add_argument(
 parser.add_argument(
     '--max_messages', type=int, default=10,
     help="number of max mailbox messages")
+parser.add_argument(
+    '--software_veto', type=int, default=None,
+    help="Class name of veto plugin to apply (i.e.: RadialVeto)")
 
 
 actions = parser.add_mutually_exclusive_group()
@@ -295,6 +298,11 @@ def new_context(cores=args.cores,
                            strax.DataDirectory(output_folder)]
         context.storage[0].readonly = True
         context.storage[0].local_only = True
+
+    if software_veto_is_on():
+        
+        register_software_veto_plugins(context)
+
     return context
 
 
@@ -1640,6 +1648,37 @@ def cleanup_db():
                 break
             fail_run(rd, failure_message.format(**rd))
             abandon(mongo_id=rd['_id'])
+
+
+
+
+###########################
+# Software veto functions #
+###########################
+
+
+
+def software_veto_is_on():
+    """Decide if software veto is on based on arguments or rundoc"""
+    
+    # TODO
+    return True
+
+def register_software_veto_plugins(context):
+    """Based on the selection that we want to apply, 
+    register the correct veto plugin.
+    Probably we want to pass it as argument and if possible overwrite it from rundoc.
+    Then register a copy of all the plugins. 
+    """
+
+    # TODO
+    plugin_name = 'RadialVeto'
+
+    import straxen.plugins.raw_records_sv.software_veto as software_veto
+    plugin = getattr(straxen.plugins.raw_records_sv.software_veto, plugin_name)
+    context.register(plugin)
+
+
 
 
 if __name__ == '__main__':

--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -22,7 +22,8 @@ class EventAreaPerChannel(strax.LoopPlugin):
 
     def infer_dtype(self):
         # setting data type from peak dtype
-        pfields_=self.deps['peaks'].dtype_for('peaks').fields
+        _dtype_for = self.depends_on[1]
+        pfields_=self.deps[_dtype_for].dtype_for(_dtype_for).fields
         ## Populating data type
         infoline = {'s1': 'main S1', 
                     's2': 'main S2', 

--- a/straxen/plugins/events/event_basics.py
+++ b/straxen/plugins/events/event_basics.py
@@ -146,7 +146,9 @@ class EventBasics(strax.Plugin):
         parse x_mlp et cetera if needed to get the algorithms used and
         set required class attributes
         """
-        posrec_fields = self.deps['peak_positions'].dtype_for('peak_positions').names
+        _dtype_for = self.depends_on[2]
+
+        posrec_fields = self.deps[_dtype_for].dtype_for(_dtype_for).names
         posrec_names = [d.split('_')[-1] for d in posrec_fields if 'x_' in d]
 
         # Preserve order. "set" is not ordered and dtypes should always be ordered

--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -64,7 +64,8 @@ class MergedS2s(strax.OverlapWindowPlugin):
         self.to_pe = self.gain_model
 
     def infer_dtype(self):
-        return strax.unpack_dtype(self.deps['peaklets'].dtype_for('peaklets'))
+        _dtype_for = self.depends_on[0]
+        return strax.unpack_dtype(self.deps[_dtype_for].dtype_for(_dtype_for))
 
     def get_window_size(self):
         return 5 * (int(self.s2_merge_gap_thresholds[0][1])

--- a/straxen/plugins/merged_s2s_he/merged_s2s_he.py
+++ b/straxen/plugins/merged_s2s_he/merged_s2s_he.py
@@ -25,7 +25,9 @@ class MergedS2sHighEnergy(MergedS2s):
         return self.n_he_pmts
 
     def infer_dtype(self):
-        return strax.unpack_dtype(self.deps['peaklets_he'].dtype_for('peaklets_he'))
+        _dtype_for = self.depends_on[0] # raw_records
+
+        return strax.unpack_dtype(self.deps[_dtype_for].dtype_for(_dtype_for))
 
     def compute(self, peaklets_he):
         # There are not any lone hits for the high energy channel,

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -311,7 +311,7 @@ class Peaklets(strax.Plugin):
 
         # Drop the data_top field
         if n_top_pmts_if_digitize_top <= 0:
-            peaklets = drop_data_top_field(peaklets, self.dtype_for('peaklets'))
+            peaklets = drop_data_top_field(peaklets, self.dtype_for(self.provides[0]))
 
         return dict(peaklets=peaklets,
                     lone_hits=lone_hits)

--- a/straxen/plugins/peaks/peaks.py
+++ b/straxen/plugins/peaks/peaks.py
@@ -32,7 +32,8 @@ class Peaks(strax.Plugin):
              "It's now possible for a S1 to be inside a S2 post merging")
 
     def infer_dtype(self):
-        return self.deps['peaklets'].dtype_for('peaklets')
+        _dtype = self.depends_on[0] # peaklets
+        return self.deps[_dtype].dtype_for(_dtype)
 
     def compute(self, peaklets, merged_s2s):
         # Remove fake merged S2s from dirty hack, see above

--- a/straxen/plugins/peaks_he/peaks_he.py
+++ b/straxen/plugins/peaks_he/peaks_he.py
@@ -21,7 +21,8 @@ class PeaksHighEnergy(Peaks):
     child_ends_with = '_he'
 
     def infer_dtype(self):
-        return self.deps['peaklets_he'].dtype_for('peaklets')
+        _dtype_for = self.depends_on[0]
+        return self.deps[_dtype_for].dtype_for(_dtype_for)
 
     def compute(self, peaklets_he, merged_s2s_he):
         return super().compute(peaklets_he, merged_s2s_he)

--- a/straxen/plugins/raw_records/daqreader.py
+++ b/straxen/plugins/raw_records/daqreader.py
@@ -190,11 +190,14 @@ class DAQReader(strax.Plugin):
         return False
 
     def _load_chunk(self, path, start, end, kind='central'):
+
+        _dtype_for = self.depends_on[0] # raw_records
+
         records = [
             strax.load_file(
                 fn,
                 compressor=self.config["daq_compressor"],
-                dtype=self.dtype_for('raw_records'))
+                dtype=self.dtype_for(_dtype_for))
             for fn in sorted(glob.glob(f'{path}/*'))]
         records = np.concatenate(records)
         records = strax.sort_by_time(records)
@@ -271,12 +274,16 @@ class DAQReader(strax.Plugin):
         return result, break_time
 
     def _artificial_dead_time(self, start, end, dt):
+
+        _dtype_for = self.depends_on[0] # raw_records
+
+
         return strax.dict_to_rec(
             dict(time=[start],
                  length=[(end - start) // dt],
                  dt=[dt],
                  channel=[ARTIFICIAL_DEADTIME_CHANNEL]),
-            self.dtype_for('raw_records'))
+            self.dtype_for(_dtype_for))
 
     def compute(self, chunk_i):
         dt_central = self.config['daq_chunk_duration']

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -90,7 +90,7 @@ class nVETORecorder(strax.Plugin):
 
     def infer_dtype(self):
         self.record_length = strax.record_length_from_dtype(
-            self.deps[self.depends_on].dtype_for(self.depends_on))
+            self.deps[self.depends_on[0]].dtype_for(self.depends_on[0]))
 
         channel_range = self.channel_map['nveto']
         n_channel = (channel_range[1] - channel_range[0]) + 1

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -90,7 +90,7 @@ class nVETORecorder(strax.Plugin):
 
     def infer_dtype(self):
         self.record_length = strax.record_length_from_dtype(
-            self.deps['raw_records_nv'].dtype_for('raw_records_nv'))
+            self.deps[self.depends_on].dtype_for(self.depends_on))
 
         channel_range = self.channel_map['nveto']
         n_channel = (channel_range[1] - channel_range[0]) + 1

--- a/straxen/plugins/records/records.py
+++ b/straxen/plugins/records/records.py
@@ -121,7 +121,7 @@ class PulseProcessing(strax.Plugin):
     def infer_dtype(self):
         # Get record_length from the plugin making raw_records
         self.record_length = strax.record_length_from_dtype(
-            self.deps['raw_records'].dtype_for('raw_records'))
+            self.deps[self.depends_on].dtype_for(self.depends_on))
 
         dtype = dict()
         for p in self.provides:

--- a/straxen/plugins/records/records.py
+++ b/straxen/plugins/records/records.py
@@ -121,7 +121,7 @@ class PulseProcessing(strax.Plugin):
     def infer_dtype(self):
         # Get record_length from the plugin making raw_records
         self.record_length = strax.record_length_from_dtype(
-            self.deps[self.depends_on].dtype_for(self.depends_on))
+            self.deps[self.depends_on[0]].dtype_for(self.depends_on[0]))
 
         dtype = dict()
         for p in self.provides:

--- a/straxen/plugins/records_nv/records_nv.py
+++ b/straxen/plugins/records_nv/records_nv.py
@@ -53,7 +53,7 @@ class nVETOPulseProcessing(strax.Plugin):
 
     def infer_dtype(self):
         record_length = strax.record_length_from_dtype(
-            self.deps['raw_records_coin_nv'].dtype_for('raw_records_coin_nv'))
+            self.deps[self.depends_on].dtype_for(self.depends_on))
         dtype = strax.record_dtype(record_length)
         return dtype
 

--- a/straxen/plugins/records_nv/records_nv.py
+++ b/straxen/plugins/records_nv/records_nv.py
@@ -53,7 +53,7 @@ class nVETOPulseProcessing(strax.Plugin):
 
     def infer_dtype(self):
         record_length = strax.record_length_from_dtype(
-            self.deps[self.depends_on].dtype_for(self.depends_on))
+            self.deps[self.depends_on[0]].dtype_for(self.depends_on[0]))
         dtype = strax.record_dtype(record_length)
         return dtype
 


### PR DESCRIPTION
This PR is to make life to developers that want to register temporary plugins as copies of original ones (like we do for the software veto). 

It removes the hardcoded data_types in the plugins where it's not needed. 

TODO:
  - [ ] Check if some plugin is missing
  - [ ] Maybe add comments to every plugin modified
  - [ ] Update the documentation
  - [ ] Test

## What does the code in this PR do / what does it improve?

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

